### PR TITLE
runtime data errors are exceptions not asserts

### DIFF
--- a/lib/src/close.dart
+++ b/lib/src/close.dart
@@ -17,7 +17,9 @@ class Close {
   /// Deserialize a nostr close message
   /// - ["CLOSE", subscription_id]
   Close.deserialize(input) {
-    assert(input.length == 2);
+    if (input.length != 2) {
+      throw 'Invalid length for CLOSE message';
+    }
     subscriptionId = input[1];
   }
 }

--- a/lib/src/event.dart
+++ b/lib/src/event.dart
@@ -86,7 +86,9 @@ class Event {
     bool verify = true,
   }) {
     pubkey = pubkey.toLowerCase();
-    if (verify) assert(isValid() == true);
+    if (verify && isValid() == false) {
+      throw 'Invalid event';
+    }
   }
 
   /// Partial constructor, you have to fill the fields yourself

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -11,7 +11,9 @@ class Message {
   Message.deserialize(String payload) {
     dynamic data = jsonDecode(payload);
     var messages = ["EVENT", "REQ", "CLOSE", "NOTICE", "EOSE", "OK", "AUTH"];
-    assert(messages.contains(data[0]), "Unsupported payload (or NIP)");
+    if (messages.contains(data[0]) == false) {
+      throw 'Unsupported payload (or NIP)';
+    }
 
     type = data[0];
     switch (type) {

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -23,7 +23,9 @@ class Request {
   /// Deserialize a nostr request message
   /// - ["REQ", subscription_id, filter JSON, filter JSON, ...]
   Request.deserialize(input) {
-    assert(input.length >= 3);
+    if (input.length < 3) {
+      throw 'Message too short';
+    }
     subscriptionId = input[1];
     filters = [];
     for (var i = 2; i < input.length; i++) {


### PR DESCRIPTION
Resolves #27

This allows the user of the library to catch and handle runtime data errors instead of just crashing.

A further improvement would be define distinct Exception types for the library and throw those instead.
