### PR TITLE
feat: add EOSE class to obtain subscriptionId

### DIFF
--- a/lib/nostr.dart
+++ b/lib/nostr.dart
@@ -4,6 +4,7 @@
 library nostr;
 
 export 'src/event.dart';
+export 'src/eose.dart';
 export 'src/keychain.dart';
 export 'src/request.dart';
 export 'src/filter.dart';

--- a/lib/src/eose.dart
+++ b/lib/src/eose.dart
@@ -19,7 +19,7 @@ class Eose {
   /// Deserialize a nostr close message
   /// - ["CLOSE", subscription_id]
   factory Eose.deserialize(input) {
-    if (input is! List<String>) throw 'Invalid type for EOSE message';
+    if (input is! List<dynamic>) throw 'Invalid type for EOSE message';
     if (input.length != 2) throw 'Invalid length for EOSE message';
     return Eose(input[1]);
   }

--- a/lib/src/eose.dart
+++ b/lib/src/eose.dart
@@ -1,0 +1,26 @@
+import 'dart:convert';
+
+/// Indicates "end of stored events"
+///
+/// this class is mostly for getting subscription id
+class Eose {
+  /// default constructor
+  Eose(this.subscriptionId);
+
+  /// subscription_id is a random string that should be used to represent a subscription.
+  final String subscriptionId;
+
+  /// Serialize to nostr close message
+  /// - ["EOSE", subscription_id]
+  String serialize() {
+    return jsonEncode(["EOSE", subscriptionId]);
+  }
+
+  /// Deserialize a nostr close message
+  /// - ["CLOSE", subscription_id]
+  factory Eose.deserialize(input) {
+    if (input is! List<String>) throw 'Invalid type for EOSE message';
+    if (input.length != 2) throw 'Invalid length for EOSE message';
+    return Eose(input[1]);
+  }
+}

--- a/lib/src/message.dart
+++ b/lib/src/message.dart
@@ -32,6 +32,9 @@ class Message {
       case MessageType.close:
         message = Close.deserialize(data);
         break;
+      case MessageType.eose:
+        message = Eose.deserialize(data);
+        break;
       default:
         message = jsonEncode(data.sublist(1));
         break;

--- a/test/eose_test.dart
+++ b/test/eose_test.dart
@@ -1,0 +1,26 @@
+import 'package:nostr/nostr.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Eose', () {
+    test('Constructor', () {
+      String subscriptionId = generate64RandomHexChars();
+      var eose = Eose(subscriptionId);
+      expect(eose.subscriptionId, subscriptionId);
+    });
+
+    test('Eose.serialize', () {
+      String subscriptionId = generate64RandomHexChars();
+      String serialized = '["EOSE","$subscriptionId"]';
+      var eose = Eose(subscriptionId);
+      expect(eose.serialize(), serialized);
+    });
+
+    test('Eose.deserialize', () {
+      String subscriptionId = generate64RandomHexChars();
+      var serialized = ["EOSE", subscriptionId];
+      var eose = Eose.deserialize(serialized);
+      expect(eose.subscriptionId, subscriptionId);
+    });
+  });
+}

--- a/test/message_test.dart
+++ b/test/message_test.dart
@@ -35,6 +35,7 @@ void main() {
       String payload = '["EOSE", "random"]';
       var msg = Message.deserialize(payload);
       expect(msg.type, "EOSE");
+      expect(msg.message.subscriptionId, "random");
     });
 
     test('OK', () {


### PR DESCRIPTION
Hi, maybe I should've open an issue first, but I got this implementation, so I thought it'd be fast if you check the code directory.

## what I added

added class that represent EOSE mesasge.
it only has subscription field.

## motivation

Currently, there is no `subscriptionId` field in the `Message` of dart-nostr, nor is there any class representating eose.
in the case there are several subscriptions on one relay, we may want to distinguish which subscription is the received eose related to.
to achieve this, we need to know eose's subscription id.

